### PR TITLE
get rid of ruby dependency

### DIFF
--- a/pixelator
+++ b/pixelator
@@ -6,7 +6,7 @@ WIDTH=$(identify -format "%w" "$IMG")
 HEIGHT=$(identify -format "%h" "$IMG")
 
 W=16
-H=$(ruby <<< "print ($W.0/$WIDTH*$HEIGHT).floor")
+H=$(($W*$HEIGHT/$WIDTH))
 
 mkdir -p tiles
 


### PR DESCRIPTION
POSIX sh can do calculations too, although not floating-point – but at least in this case the floor function is implicit :-) To keep the error small, multiply first, then do the division.

Also get rid of the "<<<" bashism, which is not part of the specified POSIX sh language [1], although the shebang uses /bin/sh.

[1]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html